### PR TITLE
(Test PR) Fix if-condition in release workflow (previous attempt A)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ env:
 jobs:
   if_release:
     if: |
-        ${{ github.event.pull_request.merged == true }}
-        && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+        github.event.pull_request.merged == true
+        && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
*NOTE: I've realized this was not an effective test because `pyproject.toml` was not changed in this PR, so the entire workflow didn't run, and the changed if-condition was never even exercised.*

Like EliahKagan#1, my intention here is not to make direct, lasting changes to my fork. However, unlike EliahKagan#1, I may merge this temporarily to my default branch in order to test it. If I do, then that will be followed immediately by a force push to undo the effect of the merge. Ordinarily I would not force push to a repository's default branch, but this is my fork, in use only for contributing upstream.

The idea here is to allow me to test, internally to my fork, if a change I'm considering proposing for the `release.yml` workflow would really work. If it works, I might open a separate PR on the upstream repository to propose these changes.