### PR TITLE
(Test PR) Fix if-condition in release workflow (previous attempt B)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ env:
 jobs:
   if_release:
     if: |
-        ${{ github.event.pull_request.merged == true }}
-        && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+        github.event.pull_request.merged == true
+        && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
*NOTE: I've realized this was not an effective test because `pyproject.toml` was not changed in this PR, so the entire workflow didn't run, and the changed if-condition was never even exercised.*

This is the second fork-internal PR for testing my if-condition fix for the release workflow. See EliahKagan#2.

The [release](https://github.com/EliahKagan/wasm_exec/labels/release) label is applied here for testing purposes only. This does not really represent a release. Running the release job on this PR won't actually make a real release, because I (currently) have no PyPI authentication set up, and more importantly because I'm not a maintainer of the PyPI project. The point here is just to test the release workflow.