### PR TITLE
(Test PR) Fix if-condition in release workflow (A)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ env:
 jobs:
   if_release:
     if: |
-        ${{ github.event.pull_request.merged == true }}
-        && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+        github.event.pull_request.merged == true
+        && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ optional = true
 requests = "^2.31.0"
 
 [tool.poetry.group.lint.dependencies]
-ruff = "^0.0.249"
-mypy = "^0.991"
 black = "^23.1.0"
+mypy = "^0.991"
+ruff = "^0.0.249"
 types-chardet = "^5.0.4.6"
 
 


### PR DESCRIPTION
This PR, internal to my fork, is for testing whether a change I'm considering proposing to the if-condition on the release job is effective. The second commit here would not be included in an upstream PR. It is just to trigger the workflow in the first place (because a change to `pyproject.toml` is needed to do that, both with or without my changes).

**This was the *first* of two closely related test PRs.** The second is #5. This PR was for testing cases where the release label is *not* applied to the PR. Such cases should *never* trigger the release job: the if-condition should evaluate false.

My previous fork-internal PR EliahKagan#2 (see also EliahKagan#3) was meant for this, but I didn't include a change to `pyproject.toml` so it was not an effective test.

**[See all release workflow runs in my fork here.](https://github.com/EliahKagan/wasm_exec/actions/workflows/release.yml)**